### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -68,5 +68,5 @@ _redis_iam_build() {
 ######################################################################
 p6df::modules::redis::profile::mod() {
 
-  p6_return_words 'redis' '$REDIS_URL'
+  p6_return_words 'redis' "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -58,19 +58,15 @@ _redis_iam_build() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::redis::init(_module, dir)
+# Function: words redis $REDIS_URL = p6df::modules::redis::profile::mod()
 #
-#  Args:
-#	_module -
-#	dir -
+#  Returns:
+#	words - redis $REDIS_URL
 #
+#  Environment:	 REDIS_URL
 #>
 ######################################################################
-p6df::modules::redis::init() {
-  local _module="$1"
-  local dir="$2"
+p6df::modules::redis::profile::mod() {
 
-  p6_bootstrap "$dir"
-
-  p6_return_void
+  p6_return_words 'redis' '$REDIS_URL'
 }


### PR DESCRIPTION
## What
Replaces `p6df::modules::redis::init` bootstrap with `p6df::modules::redis::profile::mod` using `p6_return_words 'redis' '$REDIS_URL'`.

## Why
The bootstrap init pattern is no longer needed; adds prompt word support for displaying Redis connection info via the standard `profile::mod` convention.

## Test plan
- Source the module and call `p6df::modules::redis::profile::mod`
- Verify it returns `redis` and the value of `$REDIS_URL` as separate words

## Dependencies
None