### PR TITLE
fix(redis): rename profile::mod to prompt::env and fix return value

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -55,18 +55,7 @@ _redis_iam_build() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: words redis $REDIS_URL = p6df::modules::redis::profile::mod()
-#
-#  Returns:
-#	words - redis $REDIS_URL
-#
-#  Environment:	 REDIS_URL
-#>
-######################################################################
-p6df::modules::redis::profile::mod() {
+p6df::modules::redis::prompt::env() {
 
-  p6_return_words 'redis' "$"
+  p6_return_words "redis" '$REDIS_URL'
 }


### PR DESCRIPTION
## What
Rename `p6df::modules::redis::profile::mod` to `p6df::modules::redis::prompt::env` and fix the return value to properly reference `$REDIS_URL`.

## Why
The function was misnamed (should be `prompt::env` not `profile::mod`) and the return value was broken — returning a literal `"$"` instead of the env var reference `'$REDIS_URL'`. Also removes the outdated docblock that described the old function name.

## Test plan
- Verified diff is correct
- Function now returns `redis $REDIS_URL` as expected by the prompt system

## Dependencies
None