### PR TITLE
feat(redis): add aws iam lib helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ TODO: Add a short summary of this module.
 
 - `str token = p6df::modules::redis::aws::token::get(group_id, user_id, [region=$AWS_REGION])`
   - Args:
-    - group_id -
-    - user_id -
+    - group_id
+    - user_id
     - OPTIONAL region - [$AWS_REGION]
 
 #### p6df-redis
@@ -46,12 +46,9 @@ TODO: Add a short summary of this module.
 ##### p6df-redis/init.zsh
 
 - `p6df::modules::redis::deps()`
-- `p6df::modules::redis::external::brew()`
-- `p6df::modules::redis::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
+- `p6df::modules::redis::external::brews()`
 - `p6df::modules::redis::langs()`
+- `words redis = p6df::modules::redis::prompt::env()`
 
 ## Hierarchy
 
@@ -60,10 +57,11 @@ TODO: Add a short summary of this module.
 ├── init.zsh
 ├── lib
 │   └── aws
+│       ├── iam.zsh
 │       └── token.sh
 └── README.md
 
-3 directories, 3 files
+3 directories, 4 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -43,18 +43,17 @@ p6df::modules::redis::langs() {
   p6_return_void
 }
 
-_redis_iam_build() {
-
-  jenv local 17
-  jenv enable-plugin maven
-  jenv rehash
-
-  mvn clean
-  mvn verify
-
-  p6_return_void
-}
-
+######################################################################
+#<
+#
+# Function: words redis = p6df::modules::redis::prompt::env()
+#
+#  Returns:
+#	words - redis
+#
+#  Environment:	 REDIS_URL
+#>
+######################################################################
 p6df::modules::redis::prompt::env() {
 
   p6_return_words "redis" '$REDIS_URL'

--- a/lib/aws/iam.zsh
+++ b/lib/aws/iam.zsh
@@ -1,0 +1,12 @@
+# shellcheck shell=bash
+_redis_iam_build() {
+
+  jenv local 17
+  jenv enable-plugin maven
+  jenv rehash
+
+  mvn clean
+  mvn verify
+
+  p6_return_void
+}


### PR DESCRIPTION
**What:** Add `lib/aws/iam.zsh` helper and update `init.zsh` to source it.

**Why:** Extracts AWS IAM helpers for Redis into a dedicated lib module for better organization and reuse.

**Test plan:** Source the module in a zsh session and verify AWS IAM functions are available.

**Dependencies:** none